### PR TITLE
Add rbtrace option to Sidekiq instances.

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,12 @@ Options for Sidekiq instances may either be set inside an instance block, in whi
       <td>Sets the Sidekiq process tag</td>
       <td>&#10003;</td>
     </tr>
+    <tr>
+      <td><code>rbtrace</code></td>
+      <td><code>false</code></td>
+      <td>Requires <code>rbtrace</code> in the Sidekiq instance</td>
+      <td>&#10003;</td>
+    </tr>
   </tbody>
 </table>
 
@@ -295,7 +301,13 @@ SidekiqRunner.configure do |config|
 end
 ```
 
+### rbtrace integration
 
+For convenience (and because we found some of our Sidekiq processes gaining a lot of memory weight over time) there's a [rbtrace](https://github.com/tmm1/rbtrace) wrapper included. After you set the `:rbtrace` configuration option to your instance, you'll be able to gather all kinds of process information. For a start, try:
+
+```sh
+rbtrace -p <PID of sidekiq process> --firehose
+```
 
 ## Start & Stop
 

--- a/lib/sidekiq-runner/sidekiq_instance.rb
+++ b/lib/sidekiq-runner/sidekiq_instance.rb
@@ -4,7 +4,7 @@ module SidekiqRunner
     RUNNER_ATTRIBUTES = [:bundle_env, :chdir, :requirefile]
     RUNNER_ATTRIBUTES.each { |att| attr_accessor att }
 
-    CONFIG_FILE_ATTRIBUTES = [:concurrency, :verbose, :pidfile, :logfile, :tag]
+    CONFIG_FILE_ATTRIBUTES = [:concurrency, :verbose, :pidfile, :logfile, :tag, :rbtrace]
     CONFIG_FILE_ATTRIBUTES.each { |att| attr_accessor att }
 
     attr_reader :name, :queues
@@ -23,6 +23,7 @@ module SidekiqRunner
       @concurrency  = 4
       @verbose      = false
       @tag          = name
+      @rbtrace      = false
     end
 
     def add_queue(queue_name, weight = 1)
@@ -57,7 +58,8 @@ module SidekiqRunner
       create_directories!
 
       cmd = []
-      cmd << (bundle_env ? 'bundle exec sidekiq' : 'sidekiq')
+      cmd << 'bundle exec' if bundle_env
+      cmd << (rbtrace ? File.expand_path('../../../script/sidekiq_rbtrace', __FILE__) : 'sidekiq')
       cmd << '-d'
       cmd << "-c #{concurrency}"
       cmd << '-v' if verbose

--- a/script/sidekiq_rbtrace
+++ b/script/sidekiq_rbtrace
@@ -1,0 +1,31 @@
+#!/usr/bin/env ruby
+
+require 'rbtrace'
+
+sidekiq = `which sidekiq` rescue ''
+
+if sidekiq.empty?
+
+  # When we can't locate the Sidekiq executable, mimick
+  # its behaviour here.
+
+  require 'sidekiq/cli'
+
+  begin
+    cli = Sidekiq::CLI.instance
+    cli.parse
+    cli.run
+  rescue => e
+    raise e if $DEBUG
+    STDERR.puts e.message
+    STDERR.puts e.backtrace.join("\n")
+    exit 1
+  end
+
+else
+
+  # Otherwise load the sidekiq executable.
+
+  load sidekiq.strip
+
+end


### PR DESCRIPTION
Allows requiring 'rbtrace' inside the Sidekiq process for process
profiling.