### PR TITLE
Add configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,12 @@ God configuration options, also some of them overwritable by the config file. Fo
       <td></td>
     </tr>
     <tr>
+      <td><code>log_level</code></td>
+      <td>:warn</td>
+      <td>God's log level (<code>debug</code>,<code>info</code>,<code>warn</code>,<code>error</code> or<code>fatal</code>)</td>
+      <td></td>
+    </tr>
+    <tr>
       <td><code>process_name</code></td>
       <td><code>sidekiq</code></td>
       <td>Name of the God process (SidekiqRunner will show up as <code>SidekiqRunner/God (#{name})</code> in process listings)</td>

--- a/README.md
+++ b/README.md
@@ -91,6 +91,15 @@ SidekiqRunner.configure do |config|
     instance.add_queue 'cartman'
     instance.pidfile = '/path/to/the/pid-file.pid'
     instance.logfile = '/path/to/the/log-file.log'
+
+    # Add custom god worker configuration options
+    instance.god_config do |w|
+      w.restart_if do |restart|
+        restart.condition(:my_custom_restart_condition) do |c|
+          c.interval = 60
+        end
+      end
+    end
   end
 end
 

--- a/README.md
+++ b/README.md
@@ -323,6 +323,15 @@ SidekiqRunner.configure do |config|
 end
 ```
 
+```ruby
+SidekiqRunner.configure_god do |config|
+  config.before_start do
+    require_relative '../../lib/my_custom_restart_condition'
+  end
+  config.before_stop do ... end
+end
+```
+
 ### rbtrace integration
 
 For convenience (and because we found some of our Sidekiq processes gaining a lot of memory weight over time) there's a [rbtrace](https://github.com/tmm1/rbtrace) wrapper included. After you set the `:rbtrace` configuration option to your instance, you'll be able to gather all kinds of process information. For a start, try:

--- a/lib/sidekiq-runner/god_configuration.rb
+++ b/lib/sidekiq-runner/god_configuration.rb
@@ -15,7 +15,7 @@ module SidekiqRunner
     RUNNER_ATTRIBUTES = [:config_file, :daemonize, :port, :syslog, :events]
     RUNNER_ATTRIBUTES.each { |att| attr_accessor att }
 
-    CONFIG_FILE_ATTRIBUTES = [:process_name, :interval, :stop_timeout, :log_file, :maximum_memory_usage, :pid]
+    CONFIG_FILE_ATTRIBUTES = [:process_name, :interval, :stop_timeout, :log_file, :log_level, :maximum_memory_usage, :pid]
     CONFIG_FILE_ATTRIBUTES.each { |att| attr_accessor att }
 
     def initialize
@@ -31,6 +31,7 @@ module SidekiqRunner
       @syslog = true
       @events = true
       @pid = nil
+      @log_level = :warn
 
       # This is going to be a part of the .sock file name e.g. "/tmp/god.17165.sock" and the pidfile name
       # Change this in the configuration file to be able to run multiple instances of god.
@@ -47,7 +48,8 @@ module SidekiqRunner
         events: @events,
         config: File.expand_path("../sidekiq.god", __FILE__),
         log: @log_file,
-        pid: @pid
+        pid: @pid,
+        log_level: @log_level
       }
     end
 

--- a/lib/sidekiq-runner/god_configuration.rb
+++ b/lib/sidekiq-runner/god_configuration.rb
@@ -66,5 +66,13 @@ module SidekiqRunner
     def create_directories!
       FileUtils.mkdir_p(File.dirname(log_file))
     end
+
+    %w(start stop).each do |action|
+      attr_reader "before_#{action}_cb".to_sym
+
+      define_method("before_#{action}") do |&block|
+        instance_variable_set("@before_#{action}_cb".to_sym, block)
+      end
+    end
   end
 end

--- a/lib/sidekiq-runner/sidekiq.god
+++ b/lib/sidekiq-runner/sidekiq.god
@@ -76,6 +76,10 @@ sidekiq_config.each do |name, skiq|
       end
     end
 
+    if skiq.config_blocks.length > 0
+      skiq.config_blocks.each { |blk| blk.call(w) }
+    end
+
     w.lifecycle do |on|
       on.condition(:flapping) do |c|
         c.to_state = [:start, :restart] # If this watch is started or restarted...

--- a/lib/sidekiq-runner/sidekiq_instance.rb
+++ b/lib/sidekiq-runner/sidekiq_instance.rb
@@ -7,7 +7,7 @@ module SidekiqRunner
     CONFIG_FILE_ATTRIBUTES = [:concurrency, :verbose, :pidfile, :logfile, :tag, :rbtrace, :uid, :gid]
     CONFIG_FILE_ATTRIBUTES.each { |att| attr_accessor att }
 
-    attr_reader :name, :queues
+    attr_reader :name, :queues, :config_blocks
 
     def initialize(name)
       fail "No sidekiq instance name given!" if name.empty?
@@ -26,6 +26,7 @@ module SidekiqRunner
       @rbtrace      = false
       @uid          = nil
       @gid          = nil
+      @config_blocks = []
     end
 
     def add_queue(queue_name, weight = 1)
@@ -33,6 +34,10 @@ module SidekiqRunner
       fail "Cannot add the queue. The weight is not an integer!" unless weight.is_a? Integer
       fail "Cannot add the queue. The queue with \"#{queue_name}\" name already exist" if @queues.any? { |q| q.first == queue_name }
       @queues << [queue_name, weight]
+    end
+
+    def god_config(&block)
+      @config_blocks << block
     end
 
     def merge_config_file!(yml)


### PR DESCRIPTION
This PR adds three configuration options:

* Set the god log level via the DSL
* Add custom god configuration blocks to a sidekiq instance
* Add before_start/stop callbacks to GodConfiguration (useful when using a custom God condition and starting sidekiq_runner in a rails environment)