### PR TITLE
Fix calling sidekiq callbacks on failure and running without log file

### DIFF
--- a/lib/sidekiq-runner.rb
+++ b/lib/sidekiq-runner.rb
@@ -86,12 +86,12 @@ module SidekiqRunner
       yield if block_given?
 
     rescue SystemExit => e
-      cb = e.success? ? "#{action}_success_cb" : "#{action}_error_cb"
+      sidekiq_cb = e.success? ? "#{action}_success_cb" : "#{action}_error_cb"
     ensure
       if [:start, :stop].include? action
-        cb = "#{action}_success_cb" unless cb
-        cb = sidekiq_config.send(cb.to_sym)
-        cb.call if cb
+        sidekiq_cb = "#{action}_success_cb" unless sidekiq_cb
+        sidekiq_cb = sidekiq_config.send(sidekiq_cb.to_sym)
+        sidekiq_cb.call if sidekiq_cb
       end
     end
   end

--- a/lib/sidekiq-runner/god_configuration.rb
+++ b/lib/sidekiq-runner/god_configuration.rb
@@ -64,7 +64,7 @@ module SidekiqRunner
     end
 
     def create_directories!
-      FileUtils.mkdir_p(File.dirname(log_file))
+      FileUtils.mkdir_p(File.dirname(log_file)) if log_file
     end
 
     %w(start stop).each do |action|


### PR DESCRIPTION
When the `yield` block in `SidekiqRunner.run` fails and a `god_config`
callback was set the `cb` leaked into the `ensure` block. Since we want
to call a different callback there we have to use a different variable
name to not call `to_sym` on the proc instance `cb`.

When the `god_config` does not include a `log_file` (or it's explicitly
set to `nil`) we must not try to create the log files directory.